### PR TITLE
Github action to build and deploy to GH pages

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,0 +1,53 @@
+name: Build and deploy to GH pages
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js 24.13
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24.13
+
+    - name: NPM install
+      run: npm install
+    - name: Build
+      env:
+        NODE_ENV: production
+        BACKEND_URL: . 
+        #https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+      run: npm run build
+    - name: Copy static files to dist
+      run: cp -r ./static ./dist/static 
+    - name: Upload artifact including `static`
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: './dist'
+        
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build
       env:
         NODE_ENV: production
-        BACKEND_URL: . 
+        SERVER_URI: . 
         #https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
       run: npm run build
     - name: Copy static files to dist

--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ DEVICE_PATH=/data/local/tmp/
 NODE_ENV=development
 ```
 
-** SERVER_URI ** address where the application is reachable
-** DEVICE_PATH ** local writable folder on Android where scripts will be
-dropped.
-** NODE_ENV ** development or production environment are supported
+* **SERVER_URI** : prefix for static resources URLs
+* **DEVICE_PATH** : local writable folder on Android where scripts will be
+  dropped.
+* **NODE_ENV** : development or production environment are supported
 
 ### Customizing the Certificate
 


### PR DESCRIPTION
Following issue #1, this seems to work reasonably well. My GH pages deployment is available at https://pierre-couy.dev/webusb-unpinner/

Using `BACKEND_URL=.` for the build step worked well in practice to force webpack to use relative paths. It does not seem to break the app, but may be considered hacky